### PR TITLE
fix: Destroying context leads to undefined behaviour

### DIFF
--- a/src/secp256k1.zig
+++ b/src/secp256k1.zig
@@ -86,7 +86,7 @@ pub const Secp256k1 = struct {
     ctx: ?*secp256k1.struct_secp256k1_context_struct,
 
     pub fn deinit(self: @This()) void {
-        secp256k1.secp256k1_context_preallocated_destroy(self.ctx);
+        secp256k1.secp256k1_context_destroy(self.ctx);
     }
 
     /// Creates a schnorr signature using the given auxiliary random data.


### PR DESCRIPTION
Using the `context_preallocted_destroy` leads to undefined behaviour if the context was not created using a `context_preallocated_` function, see [`secp256k1_preallocated.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_preallocated.h#L110-L114).

As our `genNew` function uses `secp256k1_context_create` we also need to deinit with the respective function, see [`secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h#L310-L311).